### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/APIGatewaySAPIDOCAdapter.yml
+++ b/templates/APIGatewaySAPIDOCAdapter.yml
@@ -151,7 +151,7 @@ Resources:
       FunctionName: "apigw-sap-idoc-authorizer"
       Description: "Lambda function to authorize calls from SAP RFC destination"
       Handler: "index.handler"
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
       Timeout: 120
       Role: !GetAtt LambdaAuthorizerRole.Arn
       MemorySize: 512
@@ -165,7 +165,7 @@ Resources:
       FunctionName: "apigw-sap-idoc-s3"
       Description: "Lambda function to upload IDOC data to S3"
       Handler: "index.handler"
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
       Timeout: 120
       Role: !GetAtt LambdaS3AccessRole.Arn
       MemorySize: 512


### PR DESCRIPTION
CloudFormation templates in aws-cloudformation-apigw-sap-idocs have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.