### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/templates/APIGatewaySAPIDOCAdapter.yml
+++ b/templates/APIGatewaySAPIDOCAdapter.yml
@@ -151,7 +151,7 @@ Resources:
       FunctionName: "apigw-sap-idoc-authorizer"
       Description: "Lambda function to authorize calls from SAP RFC destination"
       Handler: "index.handler"
-      Runtime: "nodejs10.x"
+      Runtime: "nodejs14.x"
       Timeout: 120
       Role: !GetAtt LambdaAuthorizerRole.Arn
       MemorySize: 512
@@ -165,7 +165,7 @@ Resources:
       FunctionName: "apigw-sap-idoc-s3"
       Description: "Lambda function to upload IDOC data to S3"
       Handler: "index.handler"
-      Runtime: "nodejs10.x"
+      Runtime: "nodejs14.x"
       Timeout: 120
       Role: !GetAtt LambdaS3AccessRole.Arn
       MemorySize: 512


### PR DESCRIPTION
CloudFormation templates in aws-cloudformation-apigw-sap-idocs have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.